### PR TITLE
Add automatic release workflow on manifest.json version changes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,83 @@
+name: Auto Release on Version Change
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'custom_components/pettracer/manifest.json'
+
+jobs:
+  auto-release:
+    name: Create Release from Manifest Version
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for tags
+
+      - name: Extract version from manifest
+        id: get_version
+        run: |
+          VERSION=$(python3 -c "import json; print(json.load(open('custom_components/pettracer/manifest.json'))['version'])")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: check_tag
+        run: |
+          if git rev-parse "v${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.get_version.outputs.version }} already exists, skipping release"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.get_version.outputs.version }} does not exist, will create release"
+          fi
+
+      - name: Get commit messages since last tag
+        id: changelog
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges)
+          else
+            CHANGELOG=$(git log ${LAST_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges)
+          fi
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create ZIP package
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          cd custom_components
+          zip -r ../pettracer-${{ steps.get_version.outputs.version }}.zip pettracer/ -x "*.pyc" -x "__pycache__/*" -x "*.pyo"
+          cd ..
+
+      - name: Create GitHub Release
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.get_version.outputs.tag }}
+          name: Release ${{ steps.get_version.outputs.tag }}
+          body: |
+            ## Changes in version ${{ steps.get_version.outputs.version }}
+            
+            ${{ steps.changelog.outputs.changelog }}
+            
+            ---
+            
+            ### Installation
+            
+            This release is compatible with HACS. Install via:
+            1. HACS → Integrations → Explore & Download Repositories → Search "PetTracer"
+            2. Or manually download `pettracer-${{ steps.get_version.outputs.version }}.zip` and extract to `custom_components/`
+          files: |
+            pettracer-${{ steps.get_version.outputs.version }}.zip
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Overview

This PR adds a GitHub Actions workflow that automates the release process when the version in `manifest.json` is updated.

## What This Workflow Does

1. **Triggers** when `custom_components/pettracer/manifest.json` is modified on the master branch
2. **Extracts** the version number from manifest.json
3. **Checks** if a tag with that version already exists (prevents duplicate releases)
4. **Creates** a git tag (e.g., `v0.1.0`)
5. **Generates** changelog from commits since the last tag
6. **Creates** a GitHub release with:
   - The version tag
   - Auto-generated changelog
   - ZIP package for HACS distribution

## Benefits

- **No manual tagging** - just update the version in manifest.json and commit
- **Automatic release notes** - generated from commit messages
- **HACS compatible** - creates properly tagged releases that HACS can detect
- **Prevents duplicates** - checks if tag exists before creating release
- **Distribution ready** - includes ZIP package in the release

## Workflow

```
Update version in manifest.json → Commit & push to master
    ↓
Workflow triggers automatically
    ↓
Creates tag + GitHub release
    ↓
HACS detects new release within 24 hours
```

## Testing

Once merged, you can test by:
1. Updating the version in `manifest.json` (e.g., to `0.1.1`)
2. Committing and pushing to master
3. The workflow will automatically create a release

## Notes

- Works alongside the existing `release.yml` workflow (which handles manual releases)
- Safe to merge - won't create any releases until you update the manifest version