### PR TITLE
Add PR-only workflow policy and branch protection docs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -66,16 +66,15 @@ pytest --cov=custom_components.pettracer --cov-report=term -v
 
 ### Creating a Release
 
-1. Update version in `custom_components/pettracer/manifest.json`
-2. Commit and push changes to master:
+> **Important:** All changes must go through a pull request. Do not push directly to `master`.
+> See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full workflow policy.
+
+1. Use a Copilot task (or a feature branch + PR) to bump the version in `custom_components/pettracer/manifest.json`.
+2. Review and merge the PR into `master`.
+3. Tag the merge commit and push the tag:
    ```bash
-   git add custom_components/pettracer/manifest.json
-   git commit -m "Bump version to 1.0.4"
-   git push origin master
-   ```
-3. Create and push a version tag:
-   ```bash
-   git tag v1.0.4
+   git fetch origin
+   git tag v1.0.4 origin/master
    git push origin v1.0.4
    ```
 4. The `release-on-tag.yml` workflow automatically:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to PetTracer Home Assistant Integration
+
+## Workflow Policy: PRs Only — No Direct Commits to `master`
+
+**All changes must be made via a pull request. Direct commits to `master` are not allowed.**
+
+This applies to everyone — including automated tools and maintainers.
+
+### How Changes Are Made
+
+This repository uses [GitHub Copilot](https://github.com/features/copilot) (coding agent) to implement changes:
+
+1. A Copilot task is started with a description of the desired change.
+2. Copilot creates a new branch (e.g. `copilot/my-feature`) and implements the change there.
+3. Copilot opens a pull request targeting `master`.
+4. The PR is reviewed and merged via GitHub — never pushed directly.
+
+### Release Process
+
+Releases are triggered by pushing a version tag **after** the version bump has been merged via PR:
+
+1. Open a Copilot task to bump the version in `custom_components/pettracer/manifest.json`.
+2. Let Copilot create a branch and PR for the version bump.
+3. Review and merge the PR.
+4. Tag the merge commit and push the tag:
+   ```bash
+   git fetch origin
+   git tag vX.Y.Z origin/master
+   git push origin vX.Y.Z
+   ```
+5. The `release-on-tag.yml` workflow automatically creates the GitHub release.
+
+### Branch Protection
+
+The `master` branch has branch protection enabled:
+- Pull requests are required before merging.
+- Direct pushes to `master` are blocked.
+
+### Local Development
+
+You can still run and test locally:
+
+```bash
+# Install dependencies
+pip install -r requirements-test.txt
+
+# Run tests
+pytest --cov=custom_components.pettracer --cov-report=term -v
+
+# Lint
+ruff check custom_components/pettracer/
+```
+
+Do your work on a feature branch and open a PR — or use a Copilot task to do it for you.


### PR DESCRIPTION
## Summary

Enforces the convention that all changes must flow through Copilot-created branches and PRs — never via direct commits to `master`.

### Changes

- **Add `CONTRIBUTING.md`** — documents the PR-only + Copilot workflow policy, including the corrected release process
- **Update `.github/workflows/README.md`** — removes the 'push directly to master' release guidance and replaces it with the PR-based approach

### Also done (outside this PR)

- Branch protection has been enabled on `master` via the GitHub API: requires pull requests before merging, blocks direct pushes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>