### PR TITLE
docs: clarify that only fix/feat commits trigger release-please PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,8 +32,10 @@ Runs on every push to `master`. Uses [release-please](https://github.com/googlea
 
 **Jobs:**
 
-1. **release-please** - Creates or updates a release PR when new commits land on master
-   - Reads conventional commit prefixes (`feat:`, `fix:`, `chore:`, etc.) to determine the next version
+1. **release-please** - Creates or updates a release PR when releasable commits land on master
+   - Only `fix:` and `feat:` commits (and breaking-change `!` variants) trigger a release PR
+   - `chore:`, `docs:`, `refactor:`, `test:`, `ci:` are included in the changelog but do **not** trigger a release PR
+   - If the workflow runs with no output PR, it means no releasable commits were found — this is expected behaviour
    - Keeps `version.txt` and `custom_components/pettracer/manifest.json` in sync
    - Updates `CHANGELOG.md`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,11 @@ Releases are fully automated via [release-please](https://github.com/googleapis/
 
 There is no step 4 — no manual tagging, no manual version edits.
 
+> **Important:** Only `fix:` and `feat:` commits (and breaking-change variants) trigger a release PR.
+> `chore:`, `docs:`, `refactor:`, `test:`, and `ci:` commits are tracked in the changelog but do **not**
+> create a release PR on their own. If only non-releasable commits have been merged since the last
+> release, the release-please workflow will run successfully but produce no PR — this is expected.
+
 ### Branch Protection
 
 The `master` branch has branch protection enabled:


### PR DESCRIPTION
Adds a callout to `CONTRIBUTING.md` and `.github/workflows/README.md` explaining that:

- `chore:`, `docs:`, `refactor:`, `test:`, `ci:` commits are tracked in the changelog but do **not** trigger a release PR
- The workflow running successfully with no output PR is **expected behaviour**

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>