### PR TITLE
Make entity naming and entity_id independent of pet name

### DIFF
--- a/custom_components/pettracer/binary_sensor.py
+++ b/custom_components/pettracer/binary_sensor.py
@@ -43,9 +43,6 @@ class PetTracerAtHomeBinarySensor(CoordinatorEntity, BinarySensorEntity):
         super().__init__(coordinator)
         self._device = device
         self._device_id = device.id
-        self._device_name = (
-            device.details.name if device.details else f"PetTracer {device.id}"
-        )
         self._attr_unique_id = f"pettracer_{device.id}_at_home"
         self._attr_name = "At Home"
         self._attr_suggested_object_id = f"pettracer_{device.id}_at_home"
@@ -53,12 +50,16 @@ class PetTracerAtHomeBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device information about this sensor."""
+        device = self._get_device_data() or self._device
+        device_name = (
+            device.details.name if device.details else f"PetTracer {self._device_id}"
+        )
         return {
             "identifiers": {(DOMAIN, self._device_id)},
-            "name": self._device_name,
+            "name": device_name,
             "manufacturer": "PetTracer",
             "model": "GPS Collar",
-            "sw_version": self._device.sw if self._device.sw else None,
+            "sw_version": device.sw if device.sw else None,
         }
 
     def _get_device_data(self):
@@ -88,9 +89,6 @@ class PetTracerChargingBinarySensor(CoordinatorEntity, BinarySensorEntity):
         super().__init__(coordinator)
         self._device = device
         self._device_id = device.id
-        self._device_name = (
-            device.details.name if device.details else f"PetTracer {device.id}"
-        )
         self._attr_unique_id = f"pettracer_{device.id}_charging"
         self._attr_name = "Charging"
         self._attr_suggested_object_id = f"pettracer_{device.id}_charging"
@@ -98,12 +96,16 @@ class PetTracerChargingBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device information about this sensor."""
+        device = self._get_device_data() or self._device
+        device_name = (
+            device.details.name if device.details else f"PetTracer {self._device_id}"
+        )
         return {
             "identifiers": {(DOMAIN, self._device_id)},
-            "name": self._device_name,
+            "name": device_name,
             "manufacturer": "PetTracer",
             "model": "GPS Collar",
-            "sw_version": self._device.sw if self._device.sw else None,
+            "sw_version": device.sw if device.sw else None,
         }
 
     def _get_device_data(self):

--- a/custom_components/pettracer/binary_sensor.py
+++ b/custom_components/pettracer/binary_sensor.py
@@ -36,6 +36,7 @@ class PetTracerAtHomeBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Representation of a PetTracer at home binary sensor."""
 
     _attr_device_class = BinarySensorDeviceClass.PRESENCE
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator, device):
         """Initialize the binary sensor."""
@@ -46,7 +47,8 @@ class PetTracerAtHomeBinarySensor(CoordinatorEntity, BinarySensorEntity):
             device.details.name if device.details else f"PetTracer {device.id}"
         )
         self._attr_unique_id = f"pettracer_{device.id}_at_home"
-        self._attr_name = f"{self._device_name} At Home"
+        self._attr_name = "At Home"
+        self._attr_suggested_object_id = f"pettracer_{device.id}_at_home"
 
     @property
     def device_info(self) -> dict[str, Any]:
@@ -79,6 +81,7 @@ class PetTracerChargingBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Representation of a PetTracer charging binary sensor."""
 
     _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator, device):
         """Initialize the binary sensor."""
@@ -89,7 +92,8 @@ class PetTracerChargingBinarySensor(CoordinatorEntity, BinarySensorEntity):
             device.details.name if device.details else f"PetTracer {device.id}"
         )
         self._attr_unique_id = f"pettracer_{device.id}_charging"
-        self._attr_name = f"{self._device_name} Charging"
+        self._attr_name = "Charging"
+        self._attr_suggested_object_id = f"pettracer_{device.id}_charging"
 
     @property
     def device_info(self) -> dict[str, Any]:

--- a/custom_components/pettracer/device_tracker.py
+++ b/custom_components/pettracer/device_tracker.py
@@ -33,15 +33,19 @@ async def async_setup_entry(
 class PetTracerDeviceTracker(CoordinatorEntity, TrackerEntity):
     """Representation of a PetTracer device tracker."""
 
+    _attr_has_entity_name = True
+    _attr_name = None
+
     def __init__(self, coordinator, device):
         """Initialize the tracker."""
         super().__init__(coordinator)
         self._device = device
         self._device_id = device.id
-        self._attr_unique_id = f"pettracer_{device.id}"
-        self._attr_name = (
+        self._device_name = (
             device.details.name if device.details else f"PetTracer {device.id}"
         )
+        self._attr_unique_id = f"pettracer_{device.id}"
+        self._attr_suggested_object_id = f"pettracer_{device.id}"
 
     def _get_device_data(self):
         """Get updated device data from coordinator."""
@@ -55,7 +59,7 @@ class PetTracerDeviceTracker(CoordinatorEntity, TrackerEntity):
         """Return device information about this tracker."""
         return {
             "identifiers": {(DOMAIN, self._device.id)},
-            "name": self._attr_name,
+            "name": self._device_name,
             "manufacturer": "PetTracer",
             "model": "GPS Collar",
             "sw_version": self._device.sw if self._device.sw else None,

--- a/custom_components/pettracer/device_tracker.py
+++ b/custom_components/pettracer/device_tracker.py
@@ -41,9 +41,6 @@ class PetTracerDeviceTracker(CoordinatorEntity, TrackerEntity):
         super().__init__(coordinator)
         self._device = device
         self._device_id = device.id
-        self._device_name = (
-            device.details.name if device.details else f"PetTracer {device.id}"
-        )
         self._attr_unique_id = f"pettracer_{device.id}"
         self._attr_suggested_object_id = f"pettracer_{device.id}"
 
@@ -57,12 +54,16 @@ class PetTracerDeviceTracker(CoordinatorEntity, TrackerEntity):
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device information about this tracker."""
+        device = self._get_device_data() or self._device
+        device_name = (
+            device.details.name if device.details else f"PetTracer {self._device_id}"
+        )
         return {
-            "identifiers": {(DOMAIN, self._device.id)},
-            "name": self._device_name,
+            "identifiers": {(DOMAIN, self._device_id)},
+            "name": device_name,
             "manufacturer": "PetTracer",
             "model": "GPS Collar",
-            "sw_version": self._device.sw if self._device.sw else None,
+            "sw_version": device.sw if device.sw else None,
         }
 
     @property

--- a/custom_components/pettracer/sensor.py
+++ b/custom_components/pettracer/sensor.py
@@ -275,9 +275,6 @@ class PetTracerSensor(CoordinatorEntity, SensorEntity):
         self.entity_description = description
         self._device = device
         self._device_id = device.id
-        self._device_name = (
-            device.details.name if device.details else f"PetTracer {device.id}"
-        )
         self._attr_unique_id = f"pettracer_{device.id}_{description.key}"
         self._attr_name = description.display_name
         self._attr_suggested_object_id = f"pettracer_{device.id}_{description.key}"
@@ -285,12 +282,16 @@ class PetTracerSensor(CoordinatorEntity, SensorEntity):
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device information about this sensor."""
+        device = self._get_device_data() or self._device
+        device_name = (
+            device.details.name if device.details else f"PetTracer {self._device_id}"
+        )
         return {
             "identifiers": {(DOMAIN, self._device_id)},
-            "name": self._device_name,
+            "name": device_name,
             "manufacturer": "PetTracer",
             "model": "GPS Collar",
-            "sw_version": self._device.sw if self._device.sw else None,
+            "sw_version": device.sw if device.sw else None,
         }
 
     def _get_device_data(self):

--- a/custom_components/pettracer/sensor.py
+++ b/custom_components/pettracer/sensor.py
@@ -267,6 +267,7 @@ class PetTracerSensor(CoordinatorEntity, SensorEntity):
     """Representation of a PetTracer sensor."""
 
     entity_description: PetTracerSensorEntityDescription
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator, device, description: PetTracerSensorEntityDescription):
         """Initialize the sensor."""
@@ -278,7 +279,8 @@ class PetTracerSensor(CoordinatorEntity, SensorEntity):
             device.details.name if device.details else f"PetTracer {device.id}"
         )
         self._attr_unique_id = f"pettracer_{device.id}_{description.key}"
-        self._attr_name = f"{self._device_name} {description.display_name}"
+        self._attr_name = description.display_name
+        self._attr_suggested_object_id = f"pettracer_{device.id}_{description.key}"
 
     @property
     def device_info(self) -> dict[str, Any]:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -64,7 +64,9 @@ async def test_at_home_binary_sensor_true(hass, mock_device):
     sensor = PetTracerAtHomeBinarySensor(coordinator, mock_device)
 
     assert sensor.unique_id == "pettracer_12345_at_home"
-    assert sensor.name == "Fluffy At Home"
+    assert sensor.name == "At Home"
+    assert sensor._attr_has_entity_name is True
+    assert sensor._attr_suggested_object_id == "pettracer_12345_at_home"
     assert sensor.device_class == BinarySensorDeviceClass.PRESENCE
     assert sensor.is_on is True
 
@@ -77,7 +79,8 @@ async def test_at_home_binary_sensor_false(hass, mock_device_no_position):
     sensor = PetTracerAtHomeBinarySensor(coordinator, mock_device_no_position)
 
     assert sensor.unique_id == "pettracer_12346_at_home"
-    assert sensor.name == "Rex At Home"
+    assert sensor.name == "At Home"
+    assert sensor._attr_suggested_object_id == "pettracer_12346_at_home"
     assert sensor.is_on is False
 
 
@@ -119,7 +122,8 @@ async def test_charging_binary_sensor_true(hass, mock_device):
     sensor = PetTracerChargingBinarySensor(coordinator, mock_device)
 
     assert sensor.unique_id == "pettracer_12345_charging"
-    assert sensor.name == "Fluffy Charging"
+    assert sensor.name == "Charging"
+    assert sensor._attr_suggested_object_id == "pettracer_12345_charging"
     assert sensor.device_class == BinarySensorDeviceClass.BATTERY_CHARGING
     assert sensor.is_on is True
 
@@ -132,7 +136,8 @@ async def test_charging_binary_sensor_false(hass, mock_device_no_position):
     sensor = PetTracerChargingBinarySensor(coordinator, mock_device_no_position)
 
     assert sensor.unique_id == "pettracer_12346_charging"
-    assert sensor.name == "Rex Charging"
+    assert sensor.name == "Charging"
+    assert sensor._attr_suggested_object_id == "pettracer_12346_charging"
     assert sensor.is_on is False
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -114,6 +114,24 @@ async def test_at_home_binary_sensor_device_info(hass, mock_device):
     assert device_info["model"] == "GPS Collar"
 
 
+async def test_at_home_binary_sensor_device_info_reflects_pet_rename(hass, mock_device):
+    """Renaming the pet must update device_info without changing identifiers."""
+    coordinator = MagicMock()
+    coordinator.data = {"devices": [mock_device]}
+
+    sensor = PetTracerAtHomeBinarySensor(coordinator, mock_device)
+    assert sensor.device_info["name"] == "Fluffy"
+
+    mock_device.details.name = "Buddy"
+    coordinator.data = {"devices": [mock_device]}
+
+    assert sensor.device_info["name"] == "Buddy"
+    # Stable identifiers never move, regardless of the pet's current name.
+    assert sensor.unique_id == "pettracer_12345_at_home"
+    assert sensor._attr_suggested_object_id == "pettracer_12345_at_home"
+    assert sensor.device_info["identifiers"] == {(DOMAIN, 12345)}
+
+
 async def test_charging_binary_sensor_true(hass, mock_device):
     """Test charging binary sensor when collar is charging."""
     coordinator = MagicMock()

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -68,7 +68,7 @@ async def test_device_tracker_properties(hass, mock_device):
     # device name alone (the pet's name), rather than baking it into the entity.
     assert tracker.name is None
     assert tracker._attr_has_entity_name is True
-    assert tracker._device_name == "Fluffy"
+    assert tracker.device_info["name"] == "Fluffy"
     assert tracker._attr_suggested_object_id == "pettracer_12345"
     assert tracker.source_type == SourceType.GPS
     assert tracker.latitude == 51.5074
@@ -120,7 +120,7 @@ async def test_device_tracker_no_position(hass, mock_device_no_position):
     
     assert tracker.unique_id == "pettracer_12346"
     assert tracker.name is None
-    assert tracker._device_name == "Rex"
+    assert tracker.device_info["name"] == "Rex"
     assert tracker.latitude is None
     assert tracker.longitude is None
     assert tracker.location_accuracy == 0
@@ -198,8 +198,8 @@ async def test_device_tracker_multiple_devices(hass, mock_device, mock_device_no
     
     assert tracker1.unique_id == "pettracer_12345"
     assert tracker2.unique_id == "pettracer_12346"
-    assert tracker1._device_name == "Fluffy"
-    assert tracker2._device_name == "Rex"
+    assert tracker1.device_info["name"] == "Fluffy"
+    assert tracker2.device_info["name"] == "Rex"
     assert tracker1.latitude == 51.5074
     assert tracker2.latitude is None
 
@@ -227,6 +227,26 @@ async def test_device_tracker_coordinator_update(hass, mock_device):
     assert tracker.longitude == -0.1300
 
 
+async def test_device_tracker_device_info_reflects_pet_rename(hass, mock_device):
+    """Renaming the pet must update device_info without changing identifiers."""
+    from custom_components.pettracer.device_tracker import PetTracerDeviceTracker
+
+    coordinator = MagicMock()
+    coordinator.data = {"devices": [mock_device]}
+
+    tracker = PetTracerDeviceTracker(coordinator, mock_device)
+    assert tracker.device_info["name"] == "Fluffy"
+
+    mock_device.details.name = "Buddy"
+    coordinator.data = {"devices": [mock_device]}
+
+    assert tracker.device_info["name"] == "Buddy"
+    # Stable identifiers never move, regardless of the pet's current name.
+    assert tracker.unique_id == "pettracer_12345"
+    assert tracker._attr_suggested_object_id == "pettracer_12345"
+    assert tracker.device_info["identifiers"] == {(DOMAIN, 12345)}
+
+
 async def test_device_tracker_no_details(hass):
     """Test device tracker when device has no details."""
     from custom_components.pettracer.device_tracker import PetTracerDeviceTracker
@@ -245,7 +265,7 @@ async def test_device_tracker_no_details(hass):
     
     assert tracker.unique_id == "pettracer_99999"
     assert tracker.name is None
-    assert tracker._device_name == "PetTracer 99999"
+    assert tracker.device_info["name"] == "PetTracer 99999"
     assert tracker._attr_suggested_object_id == "pettracer_99999"
     assert tracker.latitude is None
     assert tracker.longitude is None

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -64,7 +64,12 @@ async def test_device_tracker_properties(hass, mock_device):
     tracker = PetTracerDeviceTracker(coordinator, mock_device)
     
     assert tracker.unique_id == "pettracer_12345"
-    assert tracker.name == "Fluffy"
+    # name is None so has_entity_name composes the friendly name from the
+    # device name alone (the pet's name), rather than baking it into the entity.
+    assert tracker.name is None
+    assert tracker._attr_has_entity_name is True
+    assert tracker._device_name == "Fluffy"
+    assert tracker._attr_suggested_object_id == "pettracer_12345"
     assert tracker.source_type == SourceType.GPS
     assert tracker.latitude == 51.5074
     assert tracker.longitude == -0.1278
@@ -114,7 +119,8 @@ async def test_device_tracker_no_position(hass, mock_device_no_position):
     tracker = PetTracerDeviceTracker(coordinator, mock_device_no_position)
     
     assert tracker.unique_id == "pettracer_12346"
-    assert tracker.name == "Rex"
+    assert tracker.name is None
+    assert tracker._device_name == "Rex"
     assert tracker.latitude is None
     assert tracker.longitude is None
     assert tracker.location_accuracy == 0
@@ -192,8 +198,8 @@ async def test_device_tracker_multiple_devices(hass, mock_device, mock_device_no
     
     assert tracker1.unique_id == "pettracer_12345"
     assert tracker2.unique_id == "pettracer_12346"
-    assert tracker1.name == "Fluffy"
-    assert tracker2.name == "Rex"
+    assert tracker1._device_name == "Fluffy"
+    assert tracker2._device_name == "Rex"
     assert tracker1.latitude == 51.5074
     assert tracker2.latitude is None
 
@@ -238,7 +244,9 @@ async def test_device_tracker_no_details(hass):
     tracker = PetTracerDeviceTracker(coordinator, device)
     
     assert tracker.unique_id == "pettracer_99999"
-    assert tracker.name == "PetTracer 99999"
+    assert tracker.name is None
+    assert tracker._device_name == "PetTracer 99999"
+    assert tracker._attr_suggested_object_id == "pettracer_99999"
     assert tracker.latitude is None
     assert tracker.longitude is None
     assert tracker.battery_level is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -68,7 +68,9 @@ async def test_battery_sensor(hass, mock_device):
     sensor = PetTracerSensor(coordinator, mock_device, description)
 
     assert sensor.unique_id == "pettracer_12345_battery_level"
-    assert sensor.name == "Fluffy Battery Level"
+    assert sensor.name == "Battery Level"
+    assert sensor._attr_has_entity_name is True
+    assert sensor._attr_suggested_object_id == "pettracer_12345_battery_level"
     assert sensor.device_class == SensorDeviceClass.BATTERY
     assert sensor.native_unit_of_measurement == "%"
     assert sensor.state_class == SensorStateClass.MEASUREMENT
@@ -88,7 +90,7 @@ async def test_battery_voltage_sensor(hass, mock_device):
     sensor = PetTracerSensor(coordinator, mock_device, description)
 
     assert sensor.unique_id == "pettracer_12345_battery_voltage"
-    assert sensor.name == "Fluffy Battery Voltage"
+    assert sensor.name == "Battery Voltage"
     assert sensor.device_class == SensorDeviceClass.VOLTAGE
     assert sensor.native_unit_of_measurement == "mV"
     assert sensor.state_class == SensorStateClass.MEASUREMENT
@@ -105,7 +107,7 @@ async def test_latitude_sensor(hass, mock_device):
     sensor = PetTracerSensor(coordinator, mock_device, description)
 
     assert sensor.unique_id == "pettracer_12345_latitude"
-    assert sensor.name == "Fluffy Latitude"
+    assert sensor.name == "Latitude"
     assert sensor.state_class == SensorStateClass.MEASUREMENT
     assert sensor.native_value == 51.5074
 
@@ -119,7 +121,7 @@ async def test_longitude_sensor(hass, mock_device):
     sensor = PetTracerSensor(coordinator, mock_device, description)
 
     assert sensor.unique_id == "pettracer_12345_longitude"
-    assert sensor.name == "Fluffy Longitude"
+    assert sensor.name == "Longitude"
     assert sensor.state_class == SensorStateClass.MEASUREMENT
     assert sensor.native_value == -0.1278
 
@@ -133,7 +135,7 @@ async def test_gps_accuracy_sensor(hass, mock_device):
     sensor = PetTracerSensor(coordinator, mock_device, description)
 
     assert sensor.unique_id == "pettracer_12345_gps_accuracy"
-    assert sensor.name == "Fluffy GPS Accuracy"
+    assert sensor.name == "GPS Accuracy"
     assert sensor.device_class == SensorDeviceClass.DISTANCE
     assert sensor.native_unit_of_measurement == "m"
     assert sensor.state_class == SensorStateClass.MEASUREMENT
@@ -152,7 +154,7 @@ async def test_last_contact_sensor(hass, mock_device):
     sensor = PetTracerSensor(coordinator, mock_device, description)
 
     assert sensor.unique_id == "pettracer_12345_last_contact"
-    assert sensor.name == "Fluffy Last Contact"
+    assert sensor.name == "Last Contact"
     assert sensor.device_class == SensorDeviceClass.TIMESTAMP
     assert sensor.native_value == datetime(2026, 1, 11, 10, 30, 0)
 
@@ -166,7 +168,7 @@ async def test_satellites_sensor(hass, mock_device):
     sensor = PetTracerSensor(coordinator, mock_device, description)
 
     assert sensor.unique_id == "pettracer_12345_satellites"
-    assert sensor.name == "Fluffy Satellites"
+    assert sensor.name == "Satellites"
     assert sensor.state_class == SensorStateClass.MEASUREMENT
     assert sensor.entity_category == EntityCategory.DIAGNOSTIC
     assert sensor.native_value == 8
@@ -181,7 +183,7 @@ async def test_signal_strength_sensor(hass, mock_device):
     sensor = PetTracerSensor(coordinator, mock_device, description)
 
     assert sensor.unique_id == "pettracer_12345_signal_strength"
-    assert sensor.name == "Fluffy Signal Strength"
+    assert sensor.name == "Signal Strength"
     assert sensor.device_class == SensorDeviceClass.SIGNAL_STRENGTH
     assert sensor.native_unit_of_measurement == "dBm"
     assert sensor.state_class == SensorStateClass.MEASUREMENT
@@ -198,7 +200,7 @@ async def test_position_time_sensor(hass, mock_device):
     sensor = PetTracerSensor(coordinator, mock_device, description)
 
     assert sensor.unique_id == "pettracer_12345_position_time"
-    assert sensor.name == "Fluffy Position Time"
+    assert sensor.name == "Position Time"
     assert sensor.device_class == SensorDeviceClass.TIMESTAMP
     # The value should be parsed from the mock device's timeMeasure
     assert sensor.native_value is not None
@@ -213,7 +215,7 @@ async def test_status_sensor(hass, mock_device):
     sensor = PetTracerSensor(coordinator, mock_device, description)
 
     assert sensor.unique_id == "pettracer_12345_status"
-    assert sensor.name == "Fluffy Status"
+    assert sensor.name == "Status"
     assert sensor.entity_category == EntityCategory.DIAGNOSTIC
     assert sensor.native_value == 0
 
@@ -227,7 +229,7 @@ async def test_mode_sensor(hass, mock_device):
     sensor = PetTracerSensor(coordinator, mock_device, description)
 
     assert sensor.unique_id == "pettracer_12345_mode"
-    assert sensor.name == "Fluffy Mode"
+    assert sensor.name == "Mode"
     assert sensor.native_value == "Fast"
     assert sensor.extra_state_attributes == {"mode_number": 1}
 
@@ -340,8 +342,13 @@ async def test_multiple_devices_sensors(hass, mock_device, mock_device_no_positi
 
     assert sensor1.unique_id == "pettracer_12345_battery_level"
     assert sensor2.unique_id == "pettracer_12346_battery_level"
-    assert sensor1.name == "Fluffy Battery Level"
-    assert sensor2.name == "Rex Battery Level"
+    # Entity name is identical across pets; the pet's name lives on the device,
+    # not the entity, so renaming a pet can't affect this.
+    assert sensor1.name == "Battery Level"
+    assert sensor2.name == "Battery Level"
+    # The suggested entity_id slug is keyed on device.id, not the pet's name.
+    assert sensor1._attr_suggested_object_id == "pettracer_12345_battery_level"
+    assert sensor2._attr_suggested_object_id == "pettracer_12346_battery_level"
 
 
 async def test_sensor_no_details(hass):
@@ -360,7 +367,8 @@ async def test_sensor_no_details(hass):
     sensor = PetTracerSensor(coordinator, device, description)
 
     assert sensor.unique_id == "pettracer_99999_battery_level"
-    assert sensor.name == "PetTracer 99999 Battery Level"
+    assert sensor.name == "Battery Level"
+    assert sensor._attr_suggested_object_id == "pettracer_99999_battery_level"
     assert sensor.native_value is None
 
     device_info = sensor.device_info

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -312,6 +312,25 @@ async def test_sensor_device_info(hass, mock_device):
     assert device_info["sw_version"] == 656393
 
 
+async def test_sensor_device_info_reflects_pet_rename(hass, mock_device):
+    """Renaming the pet must update device_info without changing identifiers."""
+    coordinator = MagicMock()
+    coordinator.data = {"devices": [mock_device]}
+
+    description = next(d for d in SENSOR_DESCRIPTIONS if d.key == "battery_level")
+    sensor = PetTracerSensor(coordinator, mock_device, description)
+    assert sensor.device_info["name"] == "Fluffy"
+
+    mock_device.details.name = "Buddy"
+    coordinator.data = {"devices": [mock_device]}
+
+    assert sensor.device_info["name"] == "Buddy"
+    # Stable identifiers never move, regardless of the pet's current name.
+    assert sensor.unique_id == "pettracer_12345_battery_level"
+    assert sensor._attr_suggested_object_id == "pettracer_12345_battery_level"
+    assert sensor.device_info["identifiers"] == {(DOMAIN, 12345)}
+
+
 async def test_sensor_coordinator_update(hass, mock_device):
     """Test sensor updates from coordinator."""
     coordinator = MagicMock()


### PR DESCRIPTION
## Summary
- Entity friendly names were built as `f"{pet_name} {suffix}"` (e.g. "Fluffy Battery Level"). With `has_entity_name` unset, HA slugged that combined string into the `entity_id` at first creation — so renaming the pet later left the `entity_id` permanently stuck on the old name (e.g. `sensor.fluffy_battery_level`), even though `unique_id` was already correctly keyed on `device.id`.
- Sets `_attr_has_entity_name = True` on all sensor, binary sensor, and device tracker entities, with per-entity suffix names (e.g. `"Battery Level"`, `"At Home"`, `"Charging"`). HA now composes the displayed friendly name from the device name (still the pet's name, pulled live from `device.details.name` on every coordinator refresh) + the entity's own name.
- Pins `_attr_suggested_object_id` to a `device.id`-based slug (e.g. `pettracer_12345_battery_level`) so newly created entities get an `entity_id` that's stable regardless of pet renames.
- The device tracker entity (which represents the pet itself) sets `_attr_name = None` so its friendly name is exactly the device name, matching prior behavior.
- This only affects **newly created** entities going forward — existing installs keep their current `entity_id`s untouched (HA doesn't auto-migrate `entity_id`, and neither does this change, to avoid silently breaking dashboards/automations that reference the old ids).

## Test plan
- [x] Updated `tests/test_sensor.py`, `tests/test_binary_sensor.py`, `tests/test_device_tracker.py` to assert the new `name`/`_attr_suggested_object_id`/`_attr_has_entity_name` values.
- [x] Full suite passes: 74 passed, 98% coverage (`pytest --cov=custom_components.pettracer --cov-report=term -v`), above the CI 90% gate.
- [x] `ruff check` clean on the three modified platform files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)